### PR TITLE
Suppress the Contact-us element on the left panel

### DIFF
--- a/rain-classroom-helper.user.js
+++ b/rain-classroom-helper.user.js
@@ -40,7 +40,7 @@
     }
     .left .contact-us {
       bottom: 10px !important;
-      display: block !important;
+      //display: block !important;
     }
   `);
 

--- a/rain-classroom-helper.user.js
+++ b/rain-classroom-helper.user.js
@@ -38,10 +38,6 @@
     .left .panel .nav-list .nav-item .name {
       padding-left: 18px !important;
     }
-    .left .contact-us {
-      bottom: 10px !important;
-      //display: block !important;
-    }
   `);
 
   // 调整右边栏样式


### PR DESCRIPTION
The concerned element overlaps with the control bars for  handling the width of the right-panel and the iframe. It seems convenient to suppress it. I hope to move it to the footbar in future iterations.